### PR TITLE
require node 16 due to adapter-core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/dirkhe/ioBroker.webcal.git"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 16"
   },
   "dependencies": {
     "@googleapis/calendar": "^9.7.0",


### PR DESCRIPTION
Adaptr-core 3.x.x is known to fail when installed at node 14 or earlier. So this adapter reuires node 16 minimum.